### PR TITLE
Fixing a bug that caused all blank node property lists to have same id

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/deiu/gon3
+
+go 1.19
+
+require github.com/rychipman/easylex v0.0.0-20160129204217-49ee7767142f

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/rychipman/easylex v0.0.0-20160129204217-49ee7767142f h1:L2/fBPABieQnQzfV40k2Zw7IcvZbt0CN5TgwUl8zDCs=
+github.com/rychipman/easylex v0.0.0-20160129204217-49ee7767142f/go.mod h1:MZ2GRTcqmve6EoSbErWgCR+Ash4p8Gc5esHe8MDErss=

--- a/parser.go
+++ b/parser.go
@@ -2,11 +2,12 @@ package gon3
 
 import (
 	"fmt"
-	"github.com/rychipman/easylex"
 	"io"
 	"io/ioutil"
 	"net/url"
 	"strings"
+
+	"github.com/rychipman/easylex"
 )
 
 type Parser struct {
@@ -18,7 +19,7 @@ type Parser struct {
 	baseURI       *IRI
 	namespaces    map[string]*IRI
 	bNodeLabels   map[string]*BlankNode
-	lastBlankNode *BlankNode
+	lastBlankNode int
 	curSubject    Term
 	curPredicate  Term
 }
@@ -32,7 +33,7 @@ func NewParser(baseUri string) *Parser {
 		baseURI:       NewIRI(baseUri),
 		namespaces:    map[string]*IRI{}, // TODO: probably don't need these map inits
 		bNodeLabels:   map[string]*BlankNode{},
-		lastBlankNode: &BlankNode{-1, ""}, // TODO: make this initially nil
+		lastBlankNode: -1, // TODO: make this initially nil
 	}
 	return p
 }
@@ -108,13 +109,13 @@ func (p *Parser) blankNode(label string) *BlankNode {
 }
 
 func (p *Parser) newBlankNode() *BlankNode {
-	id := p.lastBlankNode.Id + 1
+	id := p.lastBlankNode + 1
 	label := fmt.Sprintf("a%d", id)
 	b := &BlankNode{
 		Id:    id,
 		Label: label,
 	}
-	p.lastBlankNode = b
+	p.lastBlankNode = id
 	return b
 }
 
@@ -482,7 +483,7 @@ func (p *Parser) parseBlankNodePropertyList() (*BlankNode, error) {
 	if err != nil {
 		return nil, err
 	}
-	bNode := p.blankNode("bnodeproplist")
+	bNode := p.blankNode("")
 	p.curSubject = bNode
 	err = p.parsePredicateObjectList()
 	if err != nil {


### PR DESCRIPTION
The problem was the use of the label "bnodeproplist" in the function parseBlankNodePropertyList(). Changing this to use empty string produces the desired output, namely all new lists get fresh blank nodes, instead of having always the same one. The use of a non-empty string here seems like unintentional to me. 

In addition to this, I also changed the field "lastBlankNode" to be just an int, as it seems less prone to problems with passing pointers to nodes, and indeed the .Id field  was the only relevant one in the older version anyway. 

As with rdf2go, I also added .mod and .sum files.