### PR TITLE
Support escaped escapes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/deiu/gon3
 
-go 1.19
+go 1.23
 
 require github.com/rychipman/easylex v0.0.0-20160129204217-49ee7767142f

--- a/parser.go
+++ b/parser.go
@@ -83,7 +83,7 @@ func (p *Parser) next() easylex.Token {
 func (p *Parser) expect(typ easylex.TokenType) (easylex.Token, error) {
 	tok := p.next()
 	if tok.Typ != typ {
-		return tok, fmt.Errorf("Expected %s, got %s (type %s)", typ, tok.Val, tok.Typ)
+		return tok, fmt.Errorf("expected %v, got %s (type %v)", typ, tok.Val, tok.Typ)
 	}
 	return tok, nil
 }
@@ -316,7 +316,7 @@ func (p *Parser) parseSubject() error {
 		p.curSubject = bNode
 		return err
 	default:
-		return fmt.Errorf("Expected a subject, got %v (type %s)", tok, tok.Typ)
+		return fmt.Errorf("expected a subject, got %v (type %v)", tok, tok.Typ)
 	}
 }
 
@@ -374,7 +374,7 @@ func (p *Parser) parsePredicate() error {
 		p.curPredicate = iri
 		return err
 	default:
-		return fmt.Errorf("Expected predicate, got %v (type %s)", tok, tok.Typ)
+		return fmt.Errorf("expected predicate, got %v (type %v)", tok, tok.Typ)
 	}
 }
 
@@ -479,7 +479,7 @@ func (p *Parser) parseObject() error {
 		p.emitTriple(p.curSubject, p.curPredicate, lit)
 		return err
 	default:
-		return fmt.Errorf("Expected object, got %v (type %s)", tok, tok.Typ)
+		return fmt.Errorf("expected object, got %v (type %v)", tok, tok.Typ)
 	}
 }
 
@@ -593,7 +593,7 @@ func (p *Parser) parseRDFLiteral() (*Literal, error) {
 			}
 			lit.DatatypeIRI = iri
 		default:
-			return nil, fmt.Errorf("Expected an IRI or PName, got %s (type %s)", tok.Val, tok.Typ)
+			return nil, fmt.Errorf("expected an IRI or PName, got %s (type %v)", tok.Val, tok.Typ)
 		}
 	}
 	return lit, nil

--- a/rdf.go
+++ b/rdf.go
@@ -179,29 +179,34 @@ func unescapeEChar(s string) string {
 }
 
 func getIndexOfEscape(s string, substr string) int {
-	idx := strings.Index(s, substr)
-	if idx < 0 {
-		return idx
-	}
-
-	// search through runes backward from the index to ensure the escape isn't escaped
-	var size int
-	count := 1
-	escapeRune := []rune(substr)[0]
-	var r rune
-	for i := idx; i > 0; i -= size {
-		r, size = utf8.DecodeLastRuneInString(s[:idx])
-		if r != escapeRune {
-			break
+	for {
+		idx := strings.Index(s, substr)
+		if idx < 0 {
+			return idx
 		}
-		count++
-	}
 
-	// an even number of escape characters indicates it's escaped
-	if count%2 == 0 {
-		return -1
+		// search through runes backward from the index to ensure the escape isn't escaped
+		var size int
+		count := 1
+		escapeRune := []rune(substr)[0]
+		var r rune
+		for i := idx; i > 0; i -= size {
+			r, size = utf8.DecodeLastRuneInString(s[:i])
+			if r != escapeRune {
+				break
+			}
+			count++
+		}
+
+		// an odd number of escape characters indicates it's not escaped
+		if count%2 == 1 {
+			return idx
+		}
+
+		// skip that false match and check the rest of the string
+		idx += len(substr)
+		s = s[idx:]
 	}
-	return idx
 }
 
 func unescapeUChar(s string) string {

--- a/rdf.go
+++ b/rdf.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 )
 
 type Term interface {
@@ -177,11 +178,38 @@ func unescapeEChar(s string) string {
 	return s
 }
 
+func getIndexOfEscape(s string, substr string) int {
+	idx := strings.Index(s, substr)
+	if idx < 0 {
+		return idx
+	}
+
+	// search through runes backward from the index to ensure the escape isn't escaped
+	var size int
+	count := 1
+	escapeRune := []rune(substr)[0]
+	var r rune
+	for i := idx; i > 0; i -= size {
+		r, size = utf8.DecodeLastRuneInString(s[:idx])
+		if r != escapeRune {
+			break
+		}
+		count++
+	}
+
+	// an even number of escape characters indicates it's escaped
+	if count%2 == 0 {
+		return -1
+	}
+	return idx
+}
+
 func unescapeUChar(s string) string {
 	for {
 		var start, hex, end string
-		uIdx := strings.Index(s, `\u`)
-		UIdx := strings.Index(s, `\U`)
+		uIdx := getIndexOfEscape(s, `\u`)
+		UIdx := getIndexOfEscape(s, `\U`)
+
 		if uIdx >= 0 {
 			start = s[:uIdx]
 			if uIdx+6 > len(s) {

--- a/rdf_test.go
+++ b/rdf_test.go
@@ -60,6 +60,16 @@ func Test_unescapeUChar(t *testing.T) {
 			s:    `a \\\\user`,
 			want: `a \\\\user`,
 		},
+		{
+			name: "multiple short escapes",
+			s:    `an \u0061b\u0063 \\user`,
+			want: `an abc \\user`,
+		},
+		{
+			name: "ending with escaped escape",
+			s:    `end\\u`,
+			want: `end\\u`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/rdf_test.go
+++ b/rdf_test.go
@@ -1,0 +1,77 @@
+package gon3
+
+import (
+	"testing"
+)
+
+func Test_unescapeUChar(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		want string
+	}{
+		{
+			name: "on escapes",
+			s:    "simple",
+			want: "simple",
+		},
+		{
+			name: "empty",
+			s:    "",
+			want: "",
+		},
+		{
+			name: "single short escape",
+			s:    `ab\u0063de`,
+			want: "abcde",
+		},
+		{
+			name: "single long escape",
+			s:    `ab\U00000063de`,
+			want: "abcde",
+		},
+		{
+			name: "escaped short escape",
+			s:    `a \\user`,
+			want: `a \\user`,
+		},
+		{
+			name: "escaped long escape",
+			s:    `a \\User`,
+			want: `a \\User`,
+		},
+		{
+			name: "escaped escape before a short escape",
+			s:    `a \\\u0063lass`,
+			want: `a \\class`,
+		},
+		{
+			name: "leading short escape",
+			s:    `\u0061bc`,
+			want: "abc",
+		},
+		{
+			name: "leading escaped escape before a short escape",
+			s:    `\\\u0061bc`,
+			want: `\\abc`,
+		},
+		{
+			name: "multiple escaped escapes",
+			s:    `a \\\\user`,
+			want: `a \\\\user`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("unescapeUChar(%s) = panic: %v", tt.s, r)
+				}
+			}()
+			if got := unescapeUChar(tt.s); got != tt.want {
+				t.Errorf("unescapeUChar(%s) = %v, want %v", tt.s, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Strings like `` `a \\user` `` were failing because the function `unescapeUChar(...)` didn't catch that the backslash was escaped. I added a broken test for it and then fixed it by updating the function to walk backward through the runes when it finds the escape to ensure it's not escaped by yet another escape rune.

I also updated the go version, let me know if you wanted to keep that the way it was.

I suppose an alternative would be to combine the `unescapeUChar(...)` and `unescapeEChar(...)` functions but that would be a larger change. I also wondered if [strconv.Unquote](https://pkg.go.dev/strconv#Unquote) could be used somehow but it seems to have slightly different behavior and is a bit more strict.